### PR TITLE
Fix language stats

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,12 @@
+coverage:
+  status:
+    project: off
+    patch: off
+
+codecov:
+  ci:
+    - symboxtra.dynu.net/jenkins
+
 ignore:
     - "Pods"
     - "**/*View.swift"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ignore when calculating language stats
+lib-rtp/* linguist-vendored


### PR DESCRIPTION
Ignore the `lib-rtp` folder. This should take the 92.5% C++ out of our language stats.

Reference:
- github/linguist#137
- https://github.com/github/linguist#overrides